### PR TITLE
Feature/Hide strategies for Retired Vaults

### DIFF
--- a/components/Vaults.js
+++ b/components/Vaults.js
@@ -10,6 +10,9 @@ function	Vaults({vault, chainExplorer, isRetired, shouldHideValids}) {
 	const	[isExpandedAnimation, set_isExpandedAnimation] = React.useState(false);
 	
 	function	onExpand() {
+		if (isRetired) {
+			return null;
+		}
 		if (isExpanded) {
 			set_isExpandedAnimation(false);
 			setTimeout(() => set_isExpanded(false), 500);
@@ -23,7 +26,7 @@ function	Vaults({vault, chainExplorer, isRetired, shouldHideValids}) {
 		<div
 			key={vault.name}
 			className={'max-w-4xl w-full bg-white p-4 rounded-sm mb-0.5'}>
-			<div className={'flex flex-row items-center cursor-pointer'} onClick={onExpand}>
+			<div className={`flex flex-row items-center ${isRetired ? '' : 'cursor-pointer'}`} onClick={onExpand}>
 				<div className={'mr-4 w-8 flex justify-center items-center'} style={{minWidth: 32}}>
 					{isRetired ?
 						<IconRetired />
@@ -43,12 +46,12 @@ function	Vaults({vault, chainExplorer, isRetired, shouldHideValids}) {
 						href={`${chainExplorer}/address/${vault.address}#code`}
 						target={'_blank'}
 						rel={'noreferrer'}>
-						<IconExpand className={'mr-4'}/>
+						<IconExpand className={isRetired ? 'mr-0': 'mr-4'}/>
 					</a>
-					<IconChevron className={isExpandedAnimation ? 'transform rotate-90 transition-transform' : 'transform rotate-0 transition-transform'}/>
+					{!isRetired ? <IconChevron className={isExpandedAnimation ? 'transform rotate-90 transition-transform' : 'transform rotate-0 transition-transform'}/> : null}
 				</div>
 			</div>
-			<div className={`w-full transition-max-height duration-500 overflow-hidden ${isExpandedAnimation ? 'max-h-max' : 'max-h-0'}`}>
+			{!isRetired ? <div className={`w-full transition-max-height duration-500 overflow-hidden ${isExpandedAnimation ? 'max-h-max' : 'max-h-0'}`}>
 				{isExpanded ? (
 					<Strategies
 						isRetired={isRetired}
@@ -57,7 +60,7 @@ function	Vaults({vault, chainExplorer, isRetired, shouldHideValids}) {
 						strategiesData={vault.strategies}
 						vaultSymbol={vault.symbol} />
 				) : <div />}
-			</div>
+			</div> : null}
 		</div>
 	);
 }


### PR DESCRIPTION
## Description
Hide the strategies and disable the interactions with the accordion when the vault is retired.

Fixes #6 

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## Change details
- If retired, hide accordion
- If retired, disable onClick action
- If retired, remove chevron

## Resources
Preview deployment: https://the-vaults-at-yearn-jc9882d7i-major-eth.vercel.app