### PR TITLE
Feature/Right click on title to internal

### DIFF
--- a/components/Menu.js
+++ b/components/Menu.js
@@ -95,6 +95,7 @@ function	MenuItems() {
 function	Menu() {
 	const	{language} = useLocalization();
 	const	router = useRouter();
+	const	head = React.useRef();
 	const	[isExpanded, set_isExpanded] = React.useState(false);
 	const	[isExpandedAnimation, set_isExpandedAnimation] = React.useState(false);
 	const	[modalLanguageOpen, set_modalLanguageOpen] = React.useState(false);
@@ -110,6 +111,17 @@ function	Menu() {
 	}
 
 	React.useEffect(() => {
+		if (head?.current) {
+			head.current.oncontextmenu = (event) => {
+				if (event.button === 2) {
+					event.preventDefault();
+					router.push('/internal/missing-descriptions');
+				}
+			};
+		}
+	}, [head?.current]);
+
+	React.useEffect(() => {
 		set_isExpandedAnimation(false);
 		setTimeout(() => set_isExpanded(false), 500);
 	}, [router.pathname]);
@@ -120,7 +132,9 @@ function	Menu() {
 				<div className={'relative w-full h-full flex flex-col'}>
 					<div className={'flex flex-row justify-between items-center'}>
 						<Link href={'/'}>
-							<h1 className={'text-ygray-100 font-bold mb-6 md:mb-10 pt-6 md:pt-8 cursor-pointer'}>
+							<h1
+								ref={head}
+								className={'text-ygray-100 font-bold mb-6 md:mb-10 pt-6 md:pt-8 cursor-pointer'}>
 								{'The Vaults at '}
 								<span className={'text-yblue'}>{'Yearn'}</span>
 							</h1>


### PR DESCRIPTION
## Description
When right clicking the `The Vaults at Yearn` title, the user will be redirected to the internal section. Left click remain a redirect to `/`.
Fixes #11 

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## Change details
- Add ref on the title
- Use the `oncontextmenu` to detect right click on the title to redirect to internal

## Resources
Preview deployment: https://the-vaults-at-yearn-4yg2p3933-major-eth.vercel.app