### PR TITLE
Feature/Internal support ape.tax

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -5,6 +5,7 @@ import	useNetwork		from	'contexts/useNetwork';
 const options = ['Ethereum', 'Fantom'];
 const routerMapping = {
 	'/internal/missing-descriptions': 'Strategies',
+	'/internal/missing-ape': 'Strategies ape.tax',
 	'/internal/missing-tokens': 'Tokens',
 };
 
@@ -24,6 +25,8 @@ function	Navbar() {
 							onChange={e => {
 								if (e.target.value === 'Strategies')
 									router.push('/internal/missing-descriptions');
+								else if (e.target.value === 'Strategies ape.tax')
+									router.push('/internal/missing-ape');
 								else if (e.target.value === 'Tokens')
 									router.push('/internal/missing-tokens');
 							}}>

--- a/components/Strategies.js
+++ b/components/Strategies.js
@@ -27,6 +27,11 @@ function	Strategies({strategiesData, vaultSymbol, chainExplorer, shouldHideValid
 									{strategy.name}
 								</a>
 								<div>
+									{strategy.noIPFS ? (
+										<span className={'bg-tag-withdraw text-ygray-200 font-bold rounded-md px-2 text-xs py-1 ml-2'}>
+											{'Missing IPFS file'}
+										</span>
+									) : null}
 									{!isRetired && strategiesWithBoost.includes(strategy.name) ? (
 										<IconRocket className={'ml-2'} width={16} height={16} />
 									): null}

--- a/components/Vaults.js
+++ b/components/Vaults.js
@@ -5,7 +5,7 @@ import	IconChevron						from	'components/icons/IconChevron';
 import	IconExpand						from	'components/icons/Expand';
 import	IconRetired						from	'components/icons/IconRetired';
 
-function	Vaults({vault, chainExplorer, isRetired, shouldHideValids}) {
+function	Vaults({vault, chainExplorer, isRetired, isApeTax, shouldHideValids}) {
 	const	[isExpanded, set_isExpanded] = React.useState(false);
 	const	[isExpandedAnimation, set_isExpandedAnimation] = React.useState(false);
 	
@@ -25,17 +25,21 @@ function	Vaults({vault, chainExplorer, isRetired, shouldHideValids}) {
 			className={'max-w-4xl w-full bg-white p-4 rounded-sm mb-0.5'}>
 			<div className={'flex flex-row items-center cursor-pointer'} onClick={onExpand}>
 				<div className={'mr-4 w-8 flex justify-center items-center'} style={{minWidth: 32}}>
-					{isRetired ?
-						<IconRetired />
-						: <Image
-							src={vault.icon}
-							width={32}
-							height={32}
-							loading={'eager'} />}
+					{isApeTax ? 
+						<p className={'whitespace-nowrap'}>
+							{vault.icon}
+						</p>
+						: isRetired ?
+							<IconRetired />
+							: <Image
+								src={vault.icon}
+								width={32}
+								height={32}
+								loading={'eager'} />}
 				</div>
 				<p className={'text-ygray-200 mr-2 break-words'}>
-					{`${vault.display_name} — `}
-					<b className={'font-bold'}>{vault.name}</b>
+					{`${vault.display_name} ${isApeTax ? '' : '—'} `}
+					<b className={'font-bold'}>{isApeTax ? '' : vault.name}</b>
 				</p>
 				<div className={'ml-auto mr-1 flex flex-row justify-center'}>
 					<a

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "autoprefixer": "^10.4.0",
     "axios": "^0.24.0",
     "dotenv-webpack": "^7.0.3",
+    "ethcall": "^4.2.8",
     "ethers": "^5.5.1",
     "next": "12.0.4",
     "next-seo": "^4.28.1",

--- a/pages/api/ape-vaults.js
+++ b/pages/api/ape-vaults.js
@@ -1,0 +1,174 @@
+import	{ethers}				from	'ethers';
+import	{Provider, Contract}	from	'ethcall';
+import	{toAddress}				from	'utils';
+
+export function getProvider(chain = 1) {
+	if (chain === 1) {
+		return new ethers.providers.InfuraProvider('homestead', '9aa3d95b3bc440fa88ea12eaa4456161');
+	} else if (chain === 137) {
+		return new ethers.providers.JsonRpcProvider('https://rpc-mainnet.matic.network');
+	} else if (chain === 250) {
+		return new ethers.providers.JsonRpcProvider('https://rpc.ftm.tools');
+	} else if (chain === 56) {
+		return new ethers.providers.JsonRpcProvider('https://bsc-dataseed.binance.org');
+	} else if (chain === 1337) {
+		return new ethers.providers.JsonRpcProvider('http://localhost:8545');
+	} else if (chain === 42161) {
+		return new ethers.providers.JsonRpcProvider(`https://speedy-nodes-nyc.moralis.io/${process.env.MORALIS_ARBITRUM_KEY}/arbitrum/mainnet`);
+	} 
+	return new ethers.providers.InfuraProvider('homestead', '9aa3d95b3bc440fa88ea12eaa4456161');
+}
+
+export async function newEthCallProvider(provider, chainID) {
+	const	ethcallProvider = new Provider();
+	if (chainID === 1337) {
+		await	ethcallProvider.init(new ethers.providers.JsonRpcProvider('http://localhost:8545'));
+		ethcallProvider.multicall.address = '0xc04d660976c923ddba750341fe5923e47900cf24';
+		return ethcallProvider;
+	}
+	await	ethcallProvider.init(provider);
+	if (chainID === 250) {
+		ethcallProvider.multicall.address = '0xc04d660976c923ddba750341fe5923e47900cf24';
+	}
+	if (chainID === 42161) {
+		ethcallProvider.multicall.address = '0x10126Ceb60954BC35049f24e819A380c505f8a0F';
+	}
+	return	ethcallProvider;
+}
+
+async function fetchStrategies({vaultAddress, network}) {
+	const	vaultContract = new Contract(
+		vaultAddress,
+		[{'stateMutability': 'view', 'type': 'function', 'name': 'withdrawalQueue', 'inputs': [{'name': 'arg0', 'type': 'uint256'}], 'outputs': [{'name': '', 'type': 'address'}], 'gas': 4057}]
+	);
+	const	strategiesIndex = [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19];
+	const 	calls = [];
+	for (let i = 0; i < strategiesIndex.length; i++) {
+		calls.push(vaultContract.withdrawalQueue(strategiesIndex[i]));
+	}
+	const	ethcallProvider = await newEthCallProvider(getProvider(network), network);
+	const	callResult = await ethcallProvider.tryAll(calls);
+	return	callResult.filter(a => a !== ethers.constants.AddressZero);
+}
+
+async function fetchNames({addresses, network}) {
+	const 	calls = [];
+	for (let index = 0; index < addresses.length; index++) {
+		const	strategyContract = new Contract(
+			addresses[index],
+			[{'inputs':[],'name':'name','outputs':[{'internalType':'string','name':'','type':'string'}],'stateMutability':'view','type':'function'}]
+		);
+		calls.push(strategyContract.name());
+	}
+	const	ethcallProvider = await newEthCallProvider(getProvider(network), network);
+	const	callResult = await ethcallProvider.tryAll(calls);
+	return	callResult.filter(a => a !== ethers.constants.AddressZero);	
+}
+
+async function getVaultStrategies({vaultAddress, network, stratTree}) {
+	const	vaultStrategies = await fetchStrategies({vaultAddress, network});
+	const 	strategies = [];
+	let		hasMissingStrategiesDescriptions = false;
+	for (let i = 0; i < vaultStrategies.length; i++) {
+		const	strategyAddress = toAddress(vaultStrategies[i]);
+		const	strategyName = vaultStrategies[i].name;
+		const	details = stratTree[strategyAddress];
+		if (details) {
+			if (!details?.description) {
+				hasMissingStrategiesDescriptions = true;
+			}
+			strategies.push({
+				address: strategyAddress || '',
+				name: details?.name || strategyName || '',
+				description: (details?.description ? details.description : '')
+			});	
+		} else {
+			strategies.push({
+				address: strategyAddress || '',
+				name: strategyName || '',
+				description: ''
+			});	
+			hasMissingStrategiesDescriptions = true;
+		}
+	}
+	const	strategyWithNoName = [];
+	for (let index = 0; index < strategies.length; index++) {
+		const strategy = strategies[index];
+		if (!strategy.name) {
+			strategyWithNoName.push(strategy.address);
+		}
+	}
+	const	noNameNames = await fetchNames({addresses: strategyWithNoName, network});
+	let		noNameIndex = 0;
+	for (let index = 0; index < strategies.length; index++) {
+		const strategy = strategies[index];
+		if (!strategy.name) {
+			strategy.noIPFS = true;
+			strategy.name = noNameNames[noNameIndex++];
+		}
+	}
+
+	return ([strategies, hasMissingStrategiesDescriptions]);
+}
+
+async function getStrategies({network}) {
+	let		allStrategiesAddr = await (await fetch(`https://meta.yearn.network/strategies/${network}/all`)).json();
+	const	stratTree = {};
+	for (let index = 0; index < allStrategiesAddr.length; index++) {
+		const stratDetails = allStrategiesAddr[index];
+		for (let jindex = 0; jindex < (stratDetails.addresses).length; jindex++) {
+			const address = stratDetails.addresses[jindex];
+			stratTree[toAddress(address)] = {
+				description: stratDetails.description,
+				name: stratDetails.name,
+			};
+		}
+	}
+
+	const	vaults = (await (await fetch(`https://ape.tax/api/vaults?network=${network}`)).json()).data;
+	const	vaultsWithStrats = [];
+
+	for (let index = 0; index < vaults.length; index++) {
+		const vault = vaults[index];
+		const	[strategies, hasMissingStrategiesDescriptions] = await getVaultStrategies({
+			vaultAddress: vault.address,
+			network,
+			stratTree
+		});
+
+		vaultsWithStrats.push({
+			address: vault.address || '', 
+			symbol: vault.want.symbol || '', 
+			underlying: vault.want.address || '',
+			name: vault.title || '', 
+			display_name: vault.title || '', 
+			icon: vault.logo || '',
+			strategies,
+			hasMissingStrategiesDescriptions
+		});
+	}
+	return (vaultsWithStrats);
+}
+
+const	vaultsMapping = {};
+let		vaultsMappingAccess = {};
+export default async function handler(req, res) {
+	let		{network, revalidate} = req.query;
+	network = Number(network);
+
+	const	now = new Date().getTime();
+	const	lastAccess = vaultsMappingAccess[network] || 0;
+	if (lastAccess === 0 || ((now - lastAccess) > 5 * 60 * 1000) || revalidate === 'true' || !vaultsMapping[network]) {
+		const	result = await getStrategies({network});
+		vaultsMapping[network] = result;
+		vaultsMappingAccess[network] = now;
+	}
+	res.setHeader('Cache-Control', 's-maxage=6000'); // 60 minutes
+	return res.status(200).json(vaultsMapping[network]);
+}
+
+export async function listVaultsWithStrategies({network = 1}) {
+	network = Number(network);
+	const	result = await getStrategies({network});
+	return JSON.stringify(result);
+}

--- a/pages/internal/missing-ape.js
+++ b/pages/internal/missing-ape.js
@@ -2,7 +2,7 @@ import	React							from	'react';
 import	Navbar							from	'components/Navbar';
 import	Vaults							from	'components/Vaults';
 import	Cogs							from	'components/icons/Cogs';
-import	{listVaultsWithStrategies}		from	'pages/api/strategies';
+import	{listVaultsWithStrategies}		from	'pages/api/ape-vaults';
 import	useNetwork						from	'contexts/useNetwork';
 
 function	Index({vaults}) {
@@ -48,7 +48,12 @@ function	Index({vaults}) {
 							</p>
 						</div>
 					</div>
-					{vaultList.filter(e => e.hasMissingStrategiesDescriptions).map((vault) => <Vaults key={vault.name} vault={vault} chainExplorer={chainExplorer} shouldHideValids />)}
+					{vaultList.filter(e => e.hasMissingStrategiesDescriptions).map((vault) => <Vaults
+						key={vault.name}
+						vault={vault}
+						chainExplorer={chainExplorer}
+						shouldHideValids
+						isApeTax />)}
 				</div>
 			</section>
 		</div>

--- a/pages/internal/missing-ape.js
+++ b/pages/internal/missing-ape.js
@@ -33,7 +33,7 @@ function	Index({vaults}) {
 							<Cogs />
 						</div>
 						<div className={'flex flex-row items-center mb-8'}>
-							<h1 className={'text-4xl md:text-6xl text-ygray-100 font-bold'}>{'Strategies'}</h1>
+							<h1 className={'text-4xl md:text-6xl text-ygray-100 font-bold'}>{'Strategies Ape.tax'}</h1>
 
 							<div
 								className={'p-2 -m-2 ml-2'}
@@ -44,11 +44,11 @@ function	Index({vaults}) {
 						</div>
 						<div className={'max-w-xl space-y-6 mb-12'}>
 							<p className={'text-ygray-200'}>
-								{'List of strategies with a missing description.'}
+								{'List of strategies with a missing description from ape.tax.'}
 							</p>
 						</div>
 					</div>
-					{vaultList.filter(e => e.hasMissingStrategiesDescriptions).map((vault) => <Vaults
+					{(vaultList || [])?.filter(e => e.hasMissingStrategiesDescriptions).map((vault) => <Vaults
 						key={vault.name}
 						vault={vault}
 						chainExplorer={chainExplorer}
@@ -58,12 +58,6 @@ function	Index({vaults}) {
 			</section>
 		</div>
 	);
-}
-
-export async function getStaticProps() {
-	const	strategiesRaw = await listVaultsWithStrategies({network: 1});
-	const	vaults = JSON.parse(strategiesRaw);
-	return {props: {vaults}};
 }
 
 export default Index;

--- a/pages/internal/missing-descriptions.js
+++ b/pages/internal/missing-descriptions.js
@@ -48,17 +48,11 @@ function	Index({vaults}) {
 							</p>
 						</div>
 					</div>
-					{vaultList.filter(e => e.hasMissingStrategiesDescriptions).map((vault) => <Vaults key={vault.name} vault={vault} chainExplorer={chainExplorer} shouldHideValids />)}
+					{(vaultList || [])?.filter(e => e.hasMissingStrategiesDescriptions).map((vault) => <Vaults key={vault.name} vault={vault} chainExplorer={chainExplorer} shouldHideValids />)}
 				</div>
 			</section>
 		</div>
 	);
-}
-
-export async function getStaticProps() {
-	const	strategiesRaw = await listVaultsWithStrategies({network: 1});
-	const	vaults = JSON.parse(strategiesRaw);
-	return {props: {vaults}};
 }
 
 export default Index;

--- a/pages/internal/missing-tokens.js
+++ b/pages/internal/missing-tokens.js
@@ -134,19 +134,13 @@ function	Index({tokens}) {
 							</p>
 						</div>
 					</div>
-					{data.filter(e => e.hasMissingTokenInfo).map((vault) => (
+					{(data || [])?.filter(e => e.hasMissingTokenInfo).map((vault) => (
 						<Tokens key={vault.address} vault={vault} chainExplorer={chainExplorer} />
 					))}
 				</div>
 			</section>
 		</div>
 	);
-}
-
-export async function getStaticProps() {
-	const	tokensRaw = await listVaultsWithTokens({network: 1});
-	const	tokens = JSON.parse(tokensRaw);
-	return {props: {tokens}};
 }
 
 export default Index;

--- a/yarn.lock
+++ b/yarn.lock
@@ -64,13 +64,6 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.12.0", "@babel/runtime@^7.13.17", "@babel/runtime@^7.14.5":
-  version "7.16.5"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.5.tgz#7f3e34bf8bdbbadf03fbb7b1ea0d929569c9487a"
-  integrity sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
 "@babel/types@7.15.0":
   version "7.15.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.15.0.tgz#61af11f2286c4e9c69ca8deb5f4375a73c72dcbd"
@@ -615,14 +608,6 @@
     lodash.merge "^4.6.2"
     lodash.uniq "^4.5.0"
 
-"@types/hoist-non-react-statics@^3.3.1":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
-  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
-  dependencies:
-    "@types/react" "*"
-    hoist-non-react-statics "^3.3.0"
-
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
@@ -642,25 +627,6 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
-
-"@types/prop-types@*":
-  version "15.7.4"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
-  integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
-
-"@types/react@*":
-  version "17.0.38"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.38.tgz#f24249fefd89357d5fa71f739a686b8d7c7202bd"
-  integrity sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/scheduler@*":
-  version "0.16.2"
-  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
-  integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
 "@typescript-eslint/parser@^4.20.0":
   version "4.33.0"
@@ -1282,23 +1248,10 @@ core-js-pure@^3.19.0:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.19.1.tgz#edffc1fc7634000a55ba05e95b3f0fe9587a5aa4"
   integrity sha512-Q0Knr8Es84vtv62ei6/6jXH/7izKmOrtrxH9WJTHLCMAVeU+8TF8z8Nr08CsH4Ot0oJKzBzJJL9SJBYIv7WlfQ==
 
-core-js@^3:
-  version "3.20.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.20.1.tgz#eb1598047b7813572f1dc24b7c6a95528c99eef3"
-  integrity sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==
-
 core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
-
-cors@^2.8.5:
-  version "2.8.5"
-  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
-  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
-  dependencies:
-    object-assign "^4"
-    vary "^1"
 
 cosmiconfig@^7.0.1:
   version "7.0.1"
@@ -1401,11 +1354,6 @@ cssnano-simple@3.0.0:
   integrity sha512-oU3ueli5Dtwgh0DyeohcIEE00QVfbPR3HzyXdAl89SfnQG3y0/qcpfLVW+jPIh3/rgMZGwuW96rejZGaYE9eUg==
   dependencies:
     cssnano-preset-simple "^3.0.0"
-
-csstype@^3.0.2:
-  version "3.0.10"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.10.tgz#2ad3a7bed70f35b965707c092e5f30b327c290e5"
-  integrity sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==
 
 damerau-levenshtein@^1.0.6:
   version "1.0.7"
@@ -1929,10 +1877,10 @@ etag@1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
-ethcall@4.2.5:
-  version "4.2.5"
-  resolved "https://registry.yarnpkg.com/ethcall/-/ethcall-4.2.5.tgz#27aec44187df61fb83c9bb527b3497ca823af927"
-  integrity sha512-vqQVOwhQroUvBzndvBPq1GBVITjOC9UKvQAG0yHMcS1p/A5xR0X9X4RPQIjnzSQe0+eZhWdBQVe5IMBYhjEplg==
+ethcall@^4.2.8:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/ethcall/-/ethcall-4.2.8.tgz#e1229a071140c35cf3e272f43c0d9686bc6d2f8d"
+  integrity sha512-fCA39squLqSri7D/dTVdBrKrQI4Hb3m2WT5/vhG3FuiAFm0qbvLXvpN5xV+2C3dAEDJivkWyRXr3HrSSU3X3BA==
   dependencies:
     "@ethersproject/abi" "^5.0.0"
     "@ethersproject/bytes" "^5.0.0"
@@ -2313,13 +2261,6 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.2.0, hoist-non-react-statics@^3.3.0:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
-  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
-  dependencies:
-    react-is "^16.7.0"
-
 hsl-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hsl-regex/-/hsl-regex-1.0.0.tgz#d49330c789ed819e276a4c0d272dffa30b18fe6e"
@@ -2329,18 +2270,6 @@ hsla-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hsla-regex/-/hsla-regex-1.0.0.tgz#c1ce7a3168c8c6614033a4b5f7877f3b225f9c38"
   integrity sha1-wc56MWjIxmFAM6S194d/OyJfnDg=
-
-html-escaper@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
-  integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
-
-html-parse-stringify@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz#dfc1017347ce9f77c8141a507f233040c59c55d2"
-  integrity sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==
-  dependencies:
-    void-elements "3.1.0"
 
 html-tags@^3.1.0:
   version "3.1.0"
@@ -2362,18 +2291,6 @@ https-browserify@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
-
-i18next-fs-backend@^1.0.7:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/i18next-fs-backend/-/i18next-fs-backend-1.1.4.tgz#d0e9b9ed2fa7a0f11002d82b9fa69c3c3d6482da"
-  integrity sha512-/MfAGMP0jHonV966uFf9PkWWuDjPYLIcsipnSO3NxpNtAgRUKLTwvm85fEmsF6hGeu0zbZiCQ3W74jwO6K9uXA==
-
-i18next@^21.5.3:
-  version "21.6.3"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-21.6.3.tgz#6ab6ab1020e1f3bda71c4d1dc216ac39663d6641"
-  integrity sha512-2uuRGslNQ8m7TRllsVs4cZuei5X9OgoPRB/Sj5oadUpxZaW+NYv3srn7zR+h8bCMhkux9z8HtnJdQM5Mz+Govw==
-  dependencies:
-    "@babel/runtime" "^7.12.0"
 
 iconv-lite@0.4.24:
   version "0.4.24"
@@ -2929,19 +2846,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-next-i18next@^10.0.1:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/next-i18next/-/next-i18next-10.0.1.tgz#f42239f276b3c7a3e62b9fd83ac5c21607c2f938"
-  integrity sha512-wcpZDip4Vt89dCHgN2EKeNyA5Ckz6NenPUVpzQMphmuXyTPMqmFkWyWbpMDdg4QuMiYiX98eTeY4RLGhUXzHmQ==
-  dependencies:
-    "@babel/runtime" "^7.13.17"
-    "@types/hoist-non-react-statics" "^3.3.1"
-    core-js "^3"
-    hoist-non-react-statics "^3.2.0"
-    i18next "^21.5.3"
-    i18next-fs-backend "^1.0.7"
-    react-i18next "^11.8.13"
-
 next-seo@^4.28.1:
   version "4.28.1"
   resolved "https://registry.yarnpkg.com/next-seo/-/next-seo-4.28.1.tgz#c98ee559c8ab7196c62d0f6903afd7a8cde47a03"
@@ -3080,7 +2984,7 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
-object-assign@^4, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -3553,21 +3457,12 @@ react-dom@^17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
-react-i18next@^11.8.13:
-  version "11.15.1"
-  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-11.15.1.tgz#1dec5f2bf2cf7bc5043e9fcb391c9d6e24bb9bfe"
-  integrity sha512-lnje1uKu5XeM5MLvfbt1oygF+nEIZnpOM4Iu8bkx5ECD4XRYgi3SJDmolrp0EDxDHeK2GgFb+vEEK0hsZ9sjeA==
-  dependencies:
-    "@babel/runtime" "^7.14.5"
-    html-escaper "^2.0.2"
-    html-parse-stringify "^3.0.1"
-
 react-is@17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -4263,20 +4158,10 @@ v8-compile-cache@^2.0.3:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
   integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
 
-vary@^1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
-  integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
-
 vm-browserify@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
-
-void-elements@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-3.1.0.tgz#614f7fbf8d801f0bb5f0661f5b2f5785750e4f09"
-  integrity sha1-YU9/v42AHwu18GYfWy9XhXUOTwk=
 
 watchpack@2.1.1:
   version "2.1.1"


### PR DESCRIPTION
## Description
Add support for ape.tax on the internal section to detect strategies with no IPFS file/descriptions.
Only for Ethereum & Fantom network right now

Fixes #10 

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## Change details
- Add a new page `/internal/missing-ape`
- Add a new API route to fetch the ape.tax vaults with the attached strategies
- Add specific element for ape.tax in the vault/strategy components
- Defer api call after page loading instead of before to prevent fake freeze

## Resources
*N/A*