### PR TITLE
Feature/next buttons

### DIFF
--- a/localization/en-US/common.json
+++ b/localization/en-US/common.json
@@ -14,38 +14,52 @@
 
 	"yearn-and-curve-eth-vault-title": "Ethereum Vaults",
 	"yearn-and-curve-eth-vault-description": "Yearn Finance started and has the majority of its yVaults running on Ethereum Mainnet. We have deployed over 250 strategies and 100 yVaults on Ethereum. The ones that are currently running in production you can find in the sections below.",
-
 	"yearn-and-curve-synergy-title": "Yearn and Curve Synergy",
 	"yearn-and-curve-synergy-description": "One of the critical components of Yearn’s infrastructure includesa collaborative relationship with [Curve.fi](https://curve.fi/). Several Yearn vaults provide liquidity into Curve pools and stake the liquidity provider (LP) tokens into the respective gauges, earning CRV rewards.\n\nYearn locks **10%** of all CRV rewards earned into the yveCRV-DAO (“Backscratcher”) to obtain an additional amount of CRV.\n\nIn the strategy descriptions, vaults that are boosted are indicated with a",
 	"yearn-and-curve-synergy-description-next": "\n\nFor a deeper understanding, refer to the [Understanding Curve Boost Multipliers](/curve-boost-multipliers) section.\n\nFurthermore, the remaining 90% of the CRV earned are swapped into the respective LP tokens, and re-deposited into the vault. The only exception is the yvUSDN3Crv vault that locks 50% of the CRV earned into the Backscratcher vault and swaps the remaining 50%.",
-
 	"yearn-and-curve-yveCRV-title": "veCRV-DAO yVault\n(yveCRV-DAO)",
 	"yearn-and-curve-yveCRV-subtitle": "AKA — Backscratcher",
 	"yearn-and-curve-yveCRV-description": "This vault converts your CRV into yveCRV, earning you a continuous share of Curve fees which are boosted over what you earn staking at Curve. The more CRV converted, the greater your weekly rewards. Every Friday, these can be claimed from the vault as 3Crv (Curve’s 3pool LP token).\n\nYearn, itself, deposits 10% of all CRV earned into this vault and gives its 3crv rewards to vault token holders which is where the boosted weekly rewards come from.\n\nDepositing is non-reversible: You can only convert CRV into yveCRV, as the CRV is perpetually staked in Curve’s voting escrow. All vaults send 10% of earned CRV to this vault to sustain boost levels.\n\nFor more detailed information see this medium article: [https://medium.com/iearn/thats-boost-folks-7afae75db826](https://medium.com/iearn/thats-boost-folks-7afae75db826)",
+	"yearn-and-curve-next-button": "Next: Curve Boost Multipliers",
 
 	"curve-boost-title": "Understanding Curve\nBoost Multipliers",
 	"curve-boost-description": "Using the crvCOMP pool, as an example, liquidity providers earn approximately 12.82% APY in trading fees, and an additional 24.72% APY (as of the date of this publication) in the form of CRV rewards, if they stake their liquidity provider tokens in the Curve gauge.\n\nDepositors can boost the CRV rewards earned by locking CRV into the voting escrow module, with a max boost of **2.5x**. This size of the boost is dependent on the amount of CRV locked in the voter escrow, and the size of the deposit in the liquidity pool, however, this [calculator](https://dao.curve.fi/minter/calc) is useful in modeling potential boost multipliers. The max boost for the crvCOMP pool yields an additional 61.81% APY in the form of CRV rewards, which is displayed below.",
 	"curve-boost-description-next": "Yearn stakes the Curve liquidity provider token into the gauge to earn CRV rewards. 10% of these rewards are locked in our yveCRV-DAO vault (described above) to boost the rewards of all yVaults with Curve strategies.\n\nFor more information on Curve boost multipliers please see Curve’s documentation for this topic — [here](https://hackmd.io/CawF8dfsSk2OlN7-ubjipQ).",
-
+	"curve-boost-next-button": "Next: Ethereum: Stables",
 
 	"page-eth-stable-title": "Stable",
 	"page-eth-stable-description": "v2 yVaults are able to employ multiple strategies per vault (up to 20 strategies simultaneously), unlike v1 yVaults that are only able to employ one strategy per vault.",
+	"page-eth-stable-next-button": "Next: DeFi Tokens",
+
 	"page-eth-curve-pool-title": "Curve Finance Strategy Vaults",
 	"page-eth-curve-pool-description": "Curve yVaults accept deposits of liquidity pool tokens obtained by providing to the liquidity pools on Curve Finance. To enter these vaults you need to deposit the underlying asset(s) to their respective pool on Curve Finance.",
+	"page-eth-curve-pool-next-button": "Next: Retired Vaults",
+
 	"page-eth-defi-tokens-title": "Defi Tokens",
 	"page-eth-defi-tokens-description": "Curve yVaults accept deposits of liquidity pool tokens obtained by providing to the liquidity pools on Curve Finance. To enter these vaults you need to deposit the underlying asset(s) to their respective pool on Curve Finance.",
+	"page-eth-defi-tokens-next-button": "Next: Curve Pools",
+
 	"page-eth-retired-title": "Retired Vaults",
 	"page-eth-retired-description": "These vaults are no longer active or are in the process of migrating to a newer version and being phased out. Strategies might have been paused, deposits might be closed, or they might have been removed from the website entirely.",
+	"page-eth-retired-next-button": "Next: v1 Vaults",
+
 	"page-eth-v1-vaults-title": "v1 Vaults",
 	"page-eth-v1-vaults-description": "All v1 yVaults have migrated to v2 yVaults. Please migrate your funds via our zap or withdrawal to continue earning yield",
+	"page-eth-v1-vaults-next-button": "Next: Fantom: Stables",
 
 	"page-ftm-stable-title": "Fantom Stable",
 	"page-ftm-stable-description": "Yearn Finance is now Multi-Chain! Yearn yVaults are now [live on the Fantom Network](https://yearn.finance/#/vaults)! Just like our v2 yVaults, the new Fantom yVaults are able to employ multiple strategies per vault.",
+	"page-ftm-stable-next-button": "Next: DeFi Tokens",
+
 	"page-ftm-curve-pool-title": "Fantom Curve",
 	"page-ftm-curve-pool-description": "Curve yVaults accept deposits of liquidity pool tokens obtained by providing to the liquidity pools on Curve Finance. To enter these vaults you need to deposit the underlying asset(s) to their respective pool on Curve Finance.",
+	"page-ftm-curve-pool-next-button": "Next: Retired Vaults",
+
 	"page-ftm-defi-tokens-title": "Fantom Defi Tokens",
 	"page-ftm-defi-tokens-description": "Yearn Finance is now Multi-Chain! Yearn yVaults are now [live on the Fantom Network](https://yearn.finance/#/vaults)! Just like our v2 yVaults, the new Fantom yVaults are able to employ multiple strategies per vault.",
-	"page-ftm-retired-title": "Fantom Retired Vaults",
-	"page-ftm-retired-description": "These vaults are no longer active or are in the process of migrating to a newer version and being phased out. Strategies might have been paused, deposits might be closed, or they might have been removed from the website entirely."
+	"page-ftm-defi-tokens-next-button": "Next: Curve Pools",
 
+	"page-ftm-retired-title": "Fantom Retired Vaults",
+	"page-ftm-retired-description": "These vaults are no longer active or are in the process of migrating to a newer version and being phased out. Strategies might have been paused, deposits might be closed, or they might have been removed from the website entirely.",
+	"page-ftm-retired-next-button": "Next: Overview"
 }

--- a/pages/curve-boost-multipliers.js
+++ b/pages/curve-boost-multipliers.js
@@ -1,4 +1,5 @@
 import	React				from	'react';
+import	Link				from	'next/link';
 import	Image				from	'next/image';
 import	IconRocket			from	'components/icons/IconRocket';
 import	useLocalization		from	'contexts/useLocalization';
@@ -33,6 +34,13 @@ function	Index() {
 						<p
 							className={'text-ygray-200 whitespace-pre-line inline mt-6'}
 							dangerouslySetInnerHTML={{__html: parseMarkdown(common['curve-boost-description-next'])}} />
+					</div>
+					<div>
+						<Link href={'/ethereum/stables'}>
+							<button className={'text-white bg-yblue py-2 px-5 text-left font-bold text-sm'} style={{width: 279}}>
+								{common['curve-boost-next-button']}
+							</button>
+						</Link>
 					</div>
 				</div>
 			</div>

--- a/pages/ethereum/curve-pools.js
+++ b/pages/ethereum/curve-pools.js
@@ -1,4 +1,5 @@
 import	React							from	'react';
+import	Link							from	'next/link';
 import	Image							from	'next/image';
 import	Vaults							from	'components/Vaults';
 import	useLocalization					from	'contexts/useLocalization';
@@ -29,6 +30,13 @@ function	Index({vaults}) {
 						</p>
 					</div>
 					{vaults.map((vault) => <Vaults key={vault.name} vault={vault} chainExplorer={chainExplorer} />)}
+				</div>
+				<div className={'mt-8'}>
+					<Link href={'/ethereum/retired-vaults'}>
+						<button className={'text-white bg-yblue py-2 px-5 text-left font-bold text-sm'} style={{width: 279}}>
+							{common['page-eth-curve-pool-next-button']}
+						</button>
+					</Link>
 				</div>
 			</div>
 		</section>

--- a/pages/ethereum/defi-tokens.js
+++ b/pages/ethereum/defi-tokens.js
@@ -1,4 +1,5 @@
 import	React							from	'react';
+import	Link							from	'next/link';
 import	IconVaults						from	'components/icons/IconVaults';
 import	Vaults							from	'components/Vaults';
 import	useLocalization					from	'contexts/useLocalization';
@@ -25,6 +26,13 @@ function	Index({vaults}) {
 						</p>
 					</div>
 					{vaults.map((vault) => <Vaults key={vault.name} vault={vault} chainExplorer={chainExplorer} />)}
+				</div>
+				<div className={'mt-8'}>
+					<Link href={'/ethereum/curve-pools'}>
+						<button className={'text-white bg-yblue py-2 px-5 text-left font-bold text-sm'} style={{width: 279}}>
+							{common['page-eth-defi-tokens-next-button']}
+						</button>
+					</Link>
 				</div>
 			</div>
 		</section>

--- a/pages/ethereum/retired-vaults.js
+++ b/pages/ethereum/retired-vaults.js
@@ -1,4 +1,5 @@
 import	React							from	'react';
+import	Link							from	'next/link';
 import	Vaults							from	'components/Vaults';
 import	Sleep							from	'components/icons/Sleep';
 import	useLocalization					from	'contexts/useLocalization';
@@ -25,6 +26,13 @@ function	Index({vaults}) {
 						</p>
 					</div>
 					{vaults.map((vault) => <Vaults key={vault.name} vault={vault} chainExplorer={chainExplorer} isRetired />)}
+				</div>
+				<div className={'mt-8'}>
+					<Link href={'/ethereum/v1-vaults'}>
+						<button className={'text-white bg-yblue py-2 px-5 text-left font-bold text-sm'} style={{width: 279}}>
+							{common['page-eth-retired-next-button']}
+						</button>
+					</Link>
 				</div>
 			</div>
 		</section>

--- a/pages/ethereum/stables.js
+++ b/pages/ethereum/stables.js
@@ -1,4 +1,5 @@
 import	React							from	'react';
+import	Link							from	'next/link';
 import	IconVaults						from	'components/icons/IconVaults';
 import	Vaults							from	'components/Vaults';
 import	useLocalization					from	'contexts/useLocalization';
@@ -25,6 +26,13 @@ function	Index({vaults}) {
 						</p>
 					</div>
 					{vaults.map((vault) => <Vaults key={vault.name} vault={vault} chainExplorer={chainExplorer} />)}
+				</div>
+				<div className={'mt-8'}>
+					<Link href={'/ethereum/defi-tokens'}>
+						<button className={'text-white bg-yblue py-2 px-5 text-left font-bold text-sm'} style={{width: 279}}>
+							{common['page-eth-stable-next-button']}
+						</button>
+					</Link>
 				</div>
 			</div>
 		</section>

--- a/pages/ethereum/v1-vaults.js
+++ b/pages/ethereum/v1-vaults.js
@@ -1,4 +1,5 @@
 import	React							from	'react';
+import	Link							from	'next/link';
 import	Vaults							from	'components/Vaults';
 import	RIP								from	'components/icons/RIP';
 import	useLocalization					from	'contexts/useLocalization';
@@ -25,6 +26,13 @@ function	Index({vaults}) {
 						</p>
 					</div>
 					{vaults.map((vault) => <Vaults key={vault.name} vault={vault} chainExplorer={chainExplorer} isRetired />)}
+				</div>
+				<div className={'mt-8'}>
+					<Link href={'/fantom/stables'}>
+						<button className={'text-white bg-yblue py-2 px-5 text-left font-bold text-sm'} style={{width: 279}}>
+							{common['page-eth-v1-vaults-next-button']}
+						</button>
+					</Link>
 				</div>
 			</div>
 		</section>

--- a/pages/fantom/curve-pools.js
+++ b/pages/fantom/curve-pools.js
@@ -1,4 +1,5 @@
 import	React							from	'react';
+import	Link							from	'next/link';
 import	Image							from	'next/image';
 import	Vaults							from	'components/Vaults';
 import	useLocalization					from	'contexts/useLocalization';
@@ -29,6 +30,13 @@ function	Index({vaults}) {
 						</p>
 					</div>
 					{vaults.map((vault) => <Vaults key={vault.name} vault={vault} chainExplorer={chainExplorer} />)}
+				</div>
+				<div className={'mt-8'}>
+					<Link href={'/fantom/retired-vaults'}>
+						<button className={'text-white bg-yblue py-2 px-5 text-left font-bold text-sm'} style={{width: 279}}>
+							{common['page-ftm-curve-pool-next-button']}
+						</button>
+					</Link>
 				</div>
 			</div>
 		</section>

--- a/pages/fantom/defi-tokens.js
+++ b/pages/fantom/defi-tokens.js
@@ -1,4 +1,5 @@
 import	React							from	'react';
+import	Link							from	'next/link';
 import	Ghost							from	'components/icons/Ghost';
 import	Vaults							from	'components/Vaults';
 import	useLocalization					from	'contexts/useLocalization';
@@ -26,6 +27,13 @@ function	Index({vaults}) {
 							dangerouslySetInnerHTML={{__html: parseMarkdown(common['page-ftm-defi-tokens-description'])}} />
 					</div>
 					{vaults.map((vault) => <Vaults key={vault.name} vault={vault} chainExplorer={chainExplorer} />)}
+				</div>
+				<div className={'mt-8'}>
+					<Link href={'/fantom/curve-pools'}>
+						<button className={'text-white bg-yblue py-2 px-5 text-left font-bold text-sm'} style={{width: 279}}>
+							{common['page-ftm-defi-tokens-next-button']}
+						</button>
+					</Link>
 				</div>
 			</div>
 		</section>

--- a/pages/fantom/retired-vaults.js
+++ b/pages/fantom/retired-vaults.js
@@ -1,4 +1,5 @@
 import	React							from	'react';
+import	Link							from	'next/link';
 import	Vaults							from	'components/Vaults';
 import	Sleep							from	'components/icons/Sleep';
 import	useLocalization					from	'contexts/useLocalization';
@@ -25,6 +26,13 @@ function	Index({vaults}) {
 						</p>
 					</div>
 					{vaults.map((vault) => <Vaults key={vault.name} vault={vault} chainExplorer={chainExplorer} isRetired />)}
+				</div>
+				<div className={'mt-8'}>
+					<Link href={'/'}>
+						<button className={'text-white bg-yblue py-2 px-5 text-left font-bold text-sm'} style={{width: 279}}>
+							{common['page-ftm-retired-next-button']}
+						</button>
+					</Link>
 				</div>
 			</div>
 		</section>

--- a/pages/fantom/stables.js
+++ b/pages/fantom/stables.js
@@ -1,4 +1,5 @@
 import	React							from	'react';
+import	Link							from	'next/link';
 import	Ghost							from	'components/icons/Ghost';
 import	Vaults							from	'components/Vaults';
 import	useLocalization					from	'contexts/useLocalization';
@@ -26,6 +27,13 @@ function	Index({vaults}) {
 							dangerouslySetInnerHTML={{__html: parseMarkdown(common['page-ftm-stable-description'])}} />
 					</div>
 					{vaults.map((vault) => <Vaults key={vault.name} vault={vault} chainExplorer={chainExplorer} />)}
+				</div>
+				<div className={'mt-8'}>
+					<Link href={'/fantom/defi-tokens'}>
+						<button className={'text-white bg-yblue py-2 px-5 text-left font-bold text-sm'} style={{width: 279}}>
+							{common['page-ftm-stable-next-button']}
+						</button>
+					</Link>
 				</div>
 			</div>
 		</section>

--- a/pages/yearn-and-curve.js
+++ b/pages/yearn-and-curve.js
@@ -1,5 +1,6 @@
 import	React				from	'react';
 import	Image				from	'next/image';
+import	Link				from	'next/link';
 import	IconEth				from	'components/icons/IconEth';
 import	IconYearn			from	'components/icons/IconYearn';
 import	IconRocket			from	'components/icons/IconRocket';
@@ -71,6 +72,13 @@ function	Index() {
 						<p
 							className={'text-ygray-200 whitespace-pre-line inline mt-6'}
 							dangerouslySetInnerHTML={{__html: parseMarkdown(common['yearn-and-curve-yveCRV-description'])}} />
+					</div>
+					<div>
+						<Link href={'/curve-boost-multipliers'}>
+							<button className={'text-white bg-yblue py-2 px-5 text-left font-bold text-sm'} style={{width: 279}}>
+								{common['yearn-and-curve-next-button']}
+							</button>
+						</Link>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
## Description
Add buttons on the bottom of every page to go to the next section.
Fixes #17 

Note: Design review is ongoing, design for button is subject to change

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## Change details
Add a few new translation key : 
- `yearn-and-curve-next-button`
- `curve-boost-next-button`
- `page-eth-stable-next-button`
- `page-eth-curve-pool-next-button`
- `page-eth-defi-tokens-next-button`
- `page-eth-retired-next-button`
- `page-eth-v1-vaults-next-button`
- `page-ftm-stable-next-button`
- `page-ftm-curve-pool-next-button`
- `page-ftm-defi-tokens-next-button`
- `page-ftm-retired-next-button`

Copy the button component from overview in every related pages.

## Resources
*N/A*