### PR TITLE
Feature/Enable vault links

### DIFF
--- a/components/Vaults.js
+++ b/components/Vaults.js
@@ -8,6 +8,7 @@ import	IconRetired						from	'components/icons/IconRetired';
 function	Vaults({vault, chainExplorer, isRetired, isApeTax, shouldHideValids}) {
 	const	[isExpanded, set_isExpanded] = React.useState(false);
 	const	[isExpandedAnimation, set_isExpandedAnimation] = React.useState(false);
+	const	[isUriCopied, set_isUriCopied] = React.useState(false);
 	
 	function	onExpand() {
 		if (isRetired) {
@@ -27,7 +28,7 @@ function	Vaults({vault, chainExplorer, isRetired, isApeTax, shouldHideValids}) {
 			key={vault.name}
 			id={vault.address}
 			className={`max-w-4xl w-full bg-white ${isExpanded ? 'dark:bg-dark-400' : 'dark:bg-dark-600'} transition-colors p-4 rounded-sm mb-0.5`}>
-			<div className={`flex flex-row items-center ${isRetired ? '' : 'cursor-pointer'}`} onClick={onExpand}>
+			<div className={`flex flex-row items-center group ${isRetired ? '' : 'cursor-pointer'}`} onClick={onExpand}>
 				<div className={'mr-4 w-8 flex justify-center items-center'} style={{minWidth: 32}}>
 					{isApeTax ? 
 						<p className={'whitespace-nowrap'}>
@@ -45,6 +46,17 @@ function	Vaults({vault, chainExplorer, isRetired, isApeTax, shouldHideValids}) {
 					{`${vault.display_name} ${isApeTax ? '' : '—'} `}
 					<b className={'font-bold'}>{isApeTax ? '' : vault.name}</b>
 				</p>
+				<div onClick={(e) => {
+					e.stopPropagation();
+					set_isUriCopied(true);
+					navigator.clipboard.writeText(`${window.location.origin}${window.location.pathname}#${vault.address}`);
+					setTimeout(() => set_isUriCopied(false), 1500);
+				}}>
+					{isUriCopied ?
+						<svg aria-hidden={'true'} focusable={'false'} data-prefix={'fas'} data-icon={'clipboard-check'} className={'w-8 h-8 cursor-pointer text-yblue opacity-0 group-hover:opacity-100 text-opacity-20 hover:text-opacity-80 -m-2 p-2 transition-opacity'} role={'img'} xmlns={'http://www.w3.org/2000/svg'} viewBox={'0 0 384 512'}><path fill={'currentColor'} d={'M336 64h-53.88C268.9 26.8 233.7 0 192 0S115.1 26.8 101.9 64H48C21.5 64 0 85.48 0 112v352C0 490.5 21.5 512 48 512h288c26.5 0 48-21.48 48-48v-352C384 85.48 362.5 64 336 64zM192 64c17.67 0 32 14.33 32 32s-14.33 32-32 32S160 113.7 160 96S174.3 64 192 64zM282.9 262.8l-88 112c-4.047 5.156-10.02 8.438-16.53 9.062C177.6 383.1 176.8 384 176 384c-5.703 0-11.25-2.031-15.62-5.781l-56-48c-10.06-8.625-11.22-23.78-2.594-33.84c8.609-10.06 23.77-11.22 33.84-2.594l36.98 31.69l72.52-92.28c8.188-10.44 23.3-12.22 33.7-4.062C289.3 237.3 291.1 252.4 282.9 262.8z'}></path></svg>
+						: <svg aria-hidden={'true'} focusable={'false'} data-prefix={'fas'} data-icon={'clipboard'} className={'w-8 h-8 cursor-pointer text-ygray-200 dark:text-white opacity-0 group-hover:opacity-100 text-opacity-20 hover:text-opacity-80 -m-2 p-2 transition-opacity'} role={'img'} xmlns={'http://www.w3.org/2000/svg'} viewBox={'0 0 384 512'}><path fill={'currentColor'} d={'M336 64h-53.88C268.9 26.8 233.7 0 192 0S115.1 26.8 101.9 64H48C21.5 64 0 85.48 0 112v352C0 490.5 21.5 512 48 512h288c26.5 0 48-21.48 48-48v-352C384 85.48 362.5 64 336 64zM192 64c17.67 0 32 14.33 32 32c0 17.67-14.33 32-32 32S160 113.7 160 96C160 78.33 174.3 64 192 64zM272 224h-160C103.2 224 96 216.8 96 208C96 199.2 103.2 192 112 192h160C280.8 192 288 199.2 288 208S280.8 224 272 224z'}></path></svg>
+					}
+				</div>
 				<div className={'ml-auto mr-1 flex flex-row justify-center'}>
 					<a
 						onClick={e => e.stopPropagation()}

--- a/components/Vaults.js
+++ b/components/Vaults.js
@@ -25,6 +25,7 @@ function	Vaults({vault, chainExplorer, isRetired, isApeTax, shouldHideValids}) {
 	return (
 		<div
 			key={vault.name}
+			id={vault.address}
 			className={`max-w-4xl w-full bg-white ${isExpanded ? 'dark:bg-dark-400' : 'dark:bg-dark-600'} transition-colors p-4 rounded-sm mb-0.5`}>
 			<div className={`flex flex-row items-center ${isRetired ? '' : 'cursor-pointer'}`} onClick={onExpand}>
 				<div className={'mr-4 w-8 flex justify-center items-center'} style={{minWidth: 32}}>

--- a/style/Default.css
+++ b/style/Default.css
@@ -1,4 +1,5 @@
 * {
+	scroll-margin-top: 16px;
 	scroll-behavior: smooth;
 }
 


### PR DESCRIPTION
## Description
To ease the vault sharing, add two new functionality to the website:
- Anchor, aka links like theses : `/ethereum/curve-pools#0x2a38B9B0201Ca39B17B460eD2f11e4929559071E` where the `#0x2a38B9B0201Ca39B17B460eD2f11e4929559071E` at the end indicate the vault to scroll to
- A copy to clipboard button, next to the vault name, that will copy the vault link to the clipboard for an easy to share setup.

Should fix issue #29 

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## Change details
Cf: descriptions

## Resources
<img width="289" alt="Capture d’écran 2022-01-21 à 10 53 29" src="https://user-images.githubusercontent.com/90963895/150506599-0e349dd0-304d-43ae-ad99-19cbb6f1857d.png">
<img width="265" alt="Capture d’écran 2022-01-21 à 10 53 57" src="https://user-images.githubusercontent.com/90963895/150506593-495ea783-4935-4041-ac97-99e72770bc68.png">
