### PR TITLE
feat: add localization system to strategies

### DIFF
--- a/components/Strategies.js
+++ b/components/Strategies.js
@@ -42,7 +42,7 @@ function	Strategies({strategiesData, vaultSymbol, chainExplorer, shouldHideValid
 							</div>
 							<div className={'pr-4 w-full md:pr-16'}>
 								{strategy?.description ? 
-									<p className={'inline'} dangerouslySetInnerHTML={{__html: parseMarkdown((strategy?.localization?.[language]?.description || strategy?.description).replace(/{{token}}/g, vaultSymbol) || '')}} />
+									<p className={'inline'} dangerouslySetInnerHTML={{__html: parseMarkdown((strategy?.localization?.[language]?.description || strategy?.description || '').replace(/{{token}}/g, vaultSymbol) || '')}} />
 									:
 									<i className={'inline'} dangerouslySetInnerHTML={{__html: parseMarkdown('No description provided for this strategy.')}} />
 								}

--- a/components/Strategies.js
+++ b/components/Strategies.js
@@ -1,8 +1,11 @@
 import	React							from	'react';
 import	{parseMarkdown}					from	'utils';
 import	HeadIconRocket					from	'components/icons/HeadIconRocket';
+import	useLocalization					from	'contexts/useLocalization';
 
 function	Strategies({strategiesData, vaultSymbol, chainExplorer, shouldHideValids, isRetired}) {
+	const	{language} = useLocalization();
+
 	if (strategiesData.length === 0) {
 		return (
 			<section aria-label={'STRATEGIES'}>
@@ -24,7 +27,7 @@ function	Strategies({strategiesData, vaultSymbol, chainExplorer, shouldHideValid
 						<div className={'mb-4 text-gray-blue-1 dark:text-gray-3'}>
 							<div className={'flex flex-row items-center mb-2'}>
 								<a href={`${chainExplorer}/address/${strategy.address}#code`} target={'_blank'} className={'inline text-yearn-blue hover:underline'} rel={'noreferrer'}>
-									{strategy.name}
+									{strategy?.localization?.[language]?.name || strategy.name}
 								</a>
 								<div>
 									{strategy.noIPFS ? (
@@ -39,7 +42,7 @@ function	Strategies({strategiesData, vaultSymbol, chainExplorer, shouldHideValid
 							</div>
 							<div className={'pr-4 w-full md:pr-16'}>
 								{strategy?.description ? 
-									<p className={'inline'} dangerouslySetInnerHTML={{__html: parseMarkdown(strategy?.description.replace(/{{token}}/g, vaultSymbol) || '')}} />
+									<p className={'inline'} dangerouslySetInnerHTML={{__html: parseMarkdown((strategy?.localization?.[language]?.description || strategy?.description).replace(/{{token}}/g, vaultSymbol) || '')}} />
 									:
 									<i className={'inline'} dangerouslySetInnerHTML={{__html: parseMarkdown('No description provided for this strategy.')}} />
 								}

--- a/pages/api/strategies.js
+++ b/pages/api/strategies.js
@@ -14,13 +14,15 @@ async function getVaultStrategies({vaultStrategies, stratTree}) {
 			strategies.push({
 				address: strategyAddress || '',
 				name: details?.name || strategyName || '',
-				description: (details?.description ? details.description : '')
+				description: (details?.description ? details.description : ''),
+				localization: (details?.localization ? details.localization : {})
 			});	
 		} else {
 			strategies.push({
 				address: strategyAddress || '',
 				name: strategyName || '',
-				description: ''
+				description: '',
+				localization: {}
 			});	
 			hasMissingStrategiesDescriptions = true;
 		}
@@ -39,6 +41,7 @@ async function getStrategies({network}) {
 			stratTree[toAddress(address)] = {
 				description: stratDetails.description,
 				name: stratDetails.name,
+				localization: stratDetails.localization
 			};
 		}
 	}

--- a/pages/api/vaults.js
+++ b/pages/api/vaults.js
@@ -31,13 +31,15 @@ async function getVaultStrategies({vaultStrategies, stratTree}) {
 			strategies.push({
 				address: strategyAddress || '',
 				name: details?.name || strategyName || '',
-				description: (details?.description ? details.description : '')
+				description: (details?.description ? details.description : ''),
+				localization: (details?.localization ? details.localization : {})
 			});	
 		} else {
 			strategies.push({
 				address: strategyAddress || '',
 				name: strategyName || '',
-				description: ''
+				description: '',
+				localization: {}
 			});	
 			hasMissingStrategiesDescriptions = true;
 		}
@@ -56,6 +58,7 @@ async function getStrategies({network, isCurve, isRetired, isV1, isAll, isStable
 			stratTree[toAddress(address)] = {
 				description: stratDetails.description,
 				name: stratDetails.name,
+				localization: stratDetails.localization
 			};
 		}
 	}


### PR DESCRIPTION
## Description
Add support for the localization based on the user language.
Due to the lack of translation at the moment, this will still be to prove.

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Change details
Based on the locale, display the correct strategies description

## Resources
*N/A*