### PR TITLE
Add an internal page to see protocols with missing translations

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -7,6 +7,7 @@ const routerMapping = {
 	'/internal/missing-descriptions': 'Strategies',
 	'/internal/missing-ape': 'Strategies ape.tax',
 	'/internal/missing-tokens': 'Tokens',
+	'/internal/missing-translations': 'Translations'
 };
 
 function	Navbar() {
@@ -29,6 +30,8 @@ function	Navbar() {
 									router.push('/internal/missing-ape');
 								else if (e.target.value === 'Tokens')
 									router.push('/internal/missing-tokens');
+								else if (e.target.value === 'Translations')
+									router.push('/internal/missing-translations');
 							}}>
 							{Object.entries(routerMapping).map(([key, value]) => (
 								<option className={'cursor-pointer'} key={key} value={value}>

--- a/contexts/useNetwork.js
+++ b/contexts/useNetwork.js
@@ -2,6 +2,11 @@ import	React, {useContext, createContext}	from	'react';
 
 const options = ['Ethereum', 'Fantom'];
 
+const NETWORK_IDS = {
+	'Ethereum': 1,
+	'Fantom': 250
+};
+
 const	Network = createContext();
 export const NetworkContextApp = ({children}) => {
 	const	[currentNetwork, set_currentNetwork] = React.useState(options[0]);
@@ -11,6 +16,7 @@ export const NetworkContextApp = ({children}) => {
 		<Network.Provider
 			value={{
 				currentNetwork,
+				currentChainId: NETWORK_IDS[currentNetwork],
 				set_currentNetwork
 			}}>
 			{children}

--- a/next.config.js
+++ b/next.config.js
@@ -21,6 +21,8 @@ module.exports = ({
 		USE_PRICE_TRI_CRYPTO: false,
 		CG_IDS: [],
 		TOKENS: [],
-		ALCHEMY_KEY: process.env.ALCHEMY_KEY
+		ALCHEMY_KEY: process.env.ALCHEMY_KEY,
+		META_API_URL: 'https://meta.yearn.network',
+		META_GITHUB_URL: 'https://github.com/yearn/yearn-meta'
 	}
 });

--- a/pages/api/protocols.js
+++ b/pages/api/protocols.js
@@ -1,0 +1,69 @@
+const BASE_API_URL = 'https://meta.yearn.network';
+
+/**
+ * Return all protocols of that network
+ * 
+ * Example protocol data:
+ * 
+ * {
+ *   "$schema": "protocol",
+ *   "name": "0xDAO",
+ *   "description": "0xDAO is a protocol that is pooling money to distribute a Solidly NFT's token emissions via their governance token OXD.",
+ *   "localization": {
+ *    "en": {
+ *      "name": "0xDAO",
+ *      "description": "0xDAO is a protocol that is pooling money to distribute a Solidly NFT's token emissions via their governance token OXD."
+ *    },
+ *    ...
+ *    }
+ * }
+ */
+export async function listProtocols(chainId) {
+	const protocolApiUrl = `${BASE_API_URL}/protocols/${chainId}`;
+	const names = (await (await fetch(`${protocolApiUrl}/index`)).json())['files'];
+
+	if (!(names instanceof Array)) {
+		console.warn('names is not an array.');
+		return [];
+	}
+
+	const protocolPromises = names.map(async (name) => {
+		return await fetch(`${protocolApiUrl}/${name}`).json();
+	});
+
+	return Promise.all(protocolPromises);
+}
+
+/**
+ * Return protocols with no or missing translations
+ * 
+ * A "missingTranslationsLocales" field will be added for each protocol with missing translations
+ */
+export function filterProtocolsWithMissingTranslations(protocols, locale) {
+	if (!(protocols instanceof Array)) {
+		console.warn('protocols is not an array.');
+		return [];
+	}
+  
+	return protocols.map(protocol => {
+		const missingTranslationsLocales = findProtocolMissingTranslations(protocol);
+
+		return {
+			...protocol,
+			missingTranslationsLocales
+		};
+	}).filter(protocol => protocol.missingTranslationsLocales.length > 0 || protocol.missingTranslationsLocales.includes(locale));
+}
+
+function findProtocolMissingTranslations(protocol) {
+	const missingTranslations = [];
+	const englishDescription = protocol.description;
+
+	for (const [locale, translation] of Object.entries(protocol.localization ?? {})) {
+		if (!translation.description || (locale != 'en' && englishDescription === translation.description)) {
+			missingTranslations.push(locale);
+		}
+	}
+
+	return missingTranslations;
+}

--- a/pages/api/protocols.js
+++ b/pages/api/protocols.js
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import LOCALES from 'utils/locale';
 
 const BASE_API_URL = process.env.META_API_URL;
@@ -22,7 +23,7 @@ const BASE_API_URL = process.env.META_API_URL;
  */
 export async function listProtocols(chainId) {
 	const protocolApiUrl = `${BASE_API_URL}/protocols/${chainId}`;
-	const protocolFilenames = (await (await fetch(`${protocolApiUrl}/index`)).json())['files'];
+	const protocolFilenames = await axios.get(`${protocolApiUrl}/index`).then(res => res.data['files']);
 
 	if (!(protocolFilenames instanceof Array)) {
 		console.warn('protocolFilenames is not an array.');
@@ -30,10 +31,9 @@ export async function listProtocols(chainId) {
 	}
 
 	const protocolPromises = protocolFilenames.map(async (name) => {
-		return  fetch(`${protocolApiUrl}/${name}`).then(async (res) => {
-			const data = await res.json();
+		return  axios.get(`${protocolApiUrl}/${name}`).then(async (res) => {
 			return {
-				...data,
+				...res.data,
 				filename: name
 			};
 		});

--- a/pages/api/protocols.js
+++ b/pages/api/protocols.js
@@ -47,7 +47,7 @@ export async function listProtocols(chainId) {
  * 
  * A "missingTranslationsLocales" field will be added for each protocol with missing translations
  */
-export function filterProtocolsWithMissingTranslations(protocols = [], locale = '') {
+export function filterProtocolsWithMissingTranslations(protocols = [], localeFilter = '') {
 	if (!(protocols instanceof Array)) {
 		console.warn('protocols is not an array.');
 		return [];
@@ -61,7 +61,11 @@ export function filterProtocolsWithMissingTranslations(protocols = [], locale = 
 			missingTranslationsLocales
 		};
 	}).filter(protocol => {
-		return protocol.missingTranslationsLocales.length > 0 || protocol.missingTranslationsLocales.some(localeData => localeData.code.toLowerCase() === locale.toLowerCase());
+		if (localeFilter) {
+			return protocol.missingTranslationsLocales.some(localeData => localeData.code.toLowerCase() === localeFilter.toLowerCase());
+		}
+
+		return protocol.missingTranslationsLocales.length > 0;
 	});
 }
 

--- a/pages/api/protocols.js
+++ b/pages/api/protocols.js
@@ -28,7 +28,7 @@ export async function listProtocols(chainId) {
 	}
 
 	const protocolPromises = names.map(async (name) => {
-		return await fetch(`${protocolApiUrl}/${name}`).json();
+		return  fetch(`${protocolApiUrl}/${name}`).then(res => res.json());
 	});
 
 	return Promise.all(protocolPromises);

--- a/pages/api/protocols.js
+++ b/pages/api/protocols.js
@@ -1,6 +1,6 @@
 import LOCALES from 'utils/locale';
 
-const BASE_API_URL = 'https://meta.yearn.network';
+const BASE_API_URL = process.env.META_API_URL;
 
 /**
  * Return all protocols of that network

--- a/pages/internal/missing-translations.js
+++ b/pages/internal/missing-translations.js
@@ -59,7 +59,7 @@ function Protocol({name, filename, description, missingTranslationsLocales}) {
 
 function	Index({protocolsList}) {
 	const	[protocols, set_protocols] = React.useState(protocolsList ?? []);
-	const [localeFilter, set_localeFilter] = React.useState('');
+	const	[localeFilter, set_localeFilter] = React.useState('');
 	const	[isFetchingData, set_isFetchingData] = React.useState(false);
 	const	{currentNetwork} = useNetwork();
 

--- a/pages/internal/missing-translations.js
+++ b/pages/internal/missing-translations.js
@@ -5,7 +5,7 @@ import	useNetwork						from	'contexts/useNetwork';
 import	IconChevron						from	'components/icons/IconChevron';
 import	IconLinkOut						from	'components/icons/IconLinkOut';
 import {filterProtocolsWithMissingTranslations, listProtocols} from 'pages/api/protocols';
-import LOCALES from 'utils/locale';
+import	LOCALES							from	'utils/locale';
 
 const META_GH_PROTOCOL_URI = `${process.env.META_GITHUB_URL}/tree/master/data/protocols`;
 

--- a/pages/internal/missing-translations.js
+++ b/pages/internal/missing-translations.js
@@ -1,27 +1,30 @@
 import	React							from	'react';
 import	Navbar							from	'components/Navbar';
-import	Vaults							from	'components/Vaults';
 import	HeadIconCogs					from	'components/icons/HeadIconCogs';
-import	{listVaultsWithStrategies}		from	'pages/api/strategies';
 import	useNetwork						from	'contexts/useNetwork';
+import {filterProtocolsWithMissingTranslations, listProtocols} from 'pages/api/protocols';
 
 
-function	Index({vaults}) {
-	const	[vaultList, set_vaultList] = React.useState(vaults);
+function	Index({protocolsList}) {
+	const	[protocols, set_protocols] = React.useState(protocolsList ?? []);
+	const [protocolsWithMissingTranslations, set_protocolsWithMissingTranslations] = React.useState();
+	const [filterLocale, set_filterLocale] = React.useState('');
 	const	[isFetchingData, set_isFetchingData] = React.useState(false);
-	const	[chainExplorer, set_chainExplorer] = React.useState('https://etherscan.io');
 	const	{currentNetwork} = useNetwork();
 
 	async function	refetchData(_currentNetwork) {
 		set_isFetchingData(true);
-		const _data = await listVaultsWithStrategies({network: _currentNetwork});
-		set_vaultList(JSON.parse(_data));
+		const _data = await listProtocols(_currentNetwork);
+		set_protocols(_data);
+
+		const _protocolsWithMissingTranslations = filterProtocolsWithMissingTranslations(_data);
+		set_protocolsWithMissingTranslations(_protocolsWithMissingTranslations);
+
 		set_isFetchingData(false);
 	}
 
 	React.useEffect(() => {
 		refetchData(currentNetwork === 'Ethereum' ? 1 : currentNetwork === 'Fantom' ? 250 : 1);
-		set_chainExplorer(currentNetwork === 'Ethereum' ? 'https://etherscan.io' : currentNetwork === 'Fantom' ? 'http://ftmscan.com' : 'https://etherscan.io');
 	}, [currentNetwork]);
 
 	return (
@@ -31,12 +34,12 @@ function	Index({vaults}) {
 				<div className={'w-full max-w-5xl'}>
 					<div className={'flex flex-col'}>
 						<div className={'mb-8'}>
-							<HeadIconCogs className={'text-yearn-blue dark:text-white'} />
+							<HeadIconCogs className={'dark:text-white text-yearn-blue'} />
 						</div>
 						<div className={'w-full'}>
 							<div className={'flex flex-col'}>
 								<div className={'flex flex-row items-center mb-8 w-full'}>
-									<h1 className={'text-4xl font-bold text-dark-blue-1 dark:text-white whitespace-pre-line md:text-6xl'}>
+									<h1 className={'text-4xl font-bold dark:text-white whitespace-pre-line md:text-6xl text-dark-blue-1'}>
 										{'Translations'}
 									</h1>
 									<div
@@ -53,7 +56,7 @@ function	Index({vaults}) {
 						</div>
 					</div>
 					<div className={'w-full'}>
-						{(vaultList || [])?.filter(e => e.hasMissingStrategiesDescriptions).map((vault) => <Vaults key={vault.name} vault={vault} chainExplorer={chainExplorer} shouldHideValids />)}
+						{'Todo: render translations here'}
 					</div>
 				</div>
 			</div>

--- a/pages/internal/missing-translations.js
+++ b/pages/internal/missing-translations.js
@@ -4,7 +4,7 @@ import	HeadIconCogs					from	'components/icons/HeadIconCogs';
 import	useNetwork						from	'contexts/useNetwork';
 import	IconChevron						from	'components/icons/IconChevron';
 import	IconLinkOut						from	'components/icons/IconLinkOut';
-import {filterProtocolsWithMissingTranslations, listProtocols} from 'pages/api/protocols';
+import	{filterProtocolsWithMissingTranslations, listProtocols} from 'pages/api/protocols';
 import	LOCALES							from	'utils/locale';
 
 const META_GH_PROTOCOL_URI = `${process.env.META_GITHUB_URL}/tree/master/data/protocols`;

--- a/pages/internal/missing-translations.js
+++ b/pages/internal/missing-translations.js
@@ -7,7 +7,7 @@ import	IconLinkOut						from	'components/icons/IconLinkOut';
 import {filterProtocolsWithMissingTranslations, listProtocols} from 'pages/api/protocols';
 import LOCALES from 'utils/locale';
 
-const YEARN_META_GH_PROTOCOL_URI = 'https://github.com/yearn/yearn-meta/blob/master/data/protocols';
+const META_GH_PROTOCOL_URI = `${process.env.META_GITHUB_URL}/tree/master/data/protocols`;
 
 function Protocol({name, filename, description, missingTranslationsLocales}) {
 	const {currentChainId} = useNetwork();
@@ -38,7 +38,7 @@ function Protocol({name, filename, description, missingTranslationsLocales}) {
 					<a
 						onClick={e => e.stopPropagation()}
 						target={'_blank'}
-						href={`${YEARN_META_GH_PROTOCOL_URI}/${currentChainId}/${filename}.json`}
+						href={`${META_GH_PROTOCOL_URI}/${currentChainId}/${filename}.json`}
 						rel={'noreferrer'}>
 						<IconLinkOut className={'mr-4 w-4 h-4 text-yearn-blue'} />
 					</a>

--- a/pages/internal/missing-translations.js
+++ b/pages/internal/missing-translations.js
@@ -10,7 +10,7 @@ import	LOCALES							from	'utils/locale';
 const META_GH_PROTOCOL_URI = `${process.env.META_GITHUB_URL}/tree/master/data/protocols`;
 
 function Protocol({name, filename, description, missingTranslationsLocales}) {
-	const {currentChainId} = useNetwork();
+	const	{currentChainId} = useNetwork();
 	const	[isExpanded, set_isExpanded] = React.useState(false);
 	const	[isExpandedAnimation, set_isExpandedAnimation] = React.useState(false);
 

--- a/pages/internal/missing-translations.js
+++ b/pages/internal/missing-translations.js
@@ -5,6 +5,7 @@ import	useNetwork						from	'contexts/useNetwork';
 import	IconChevron						from	'components/icons/IconChevron';
 import	IconLinkOut						from	'components/icons/IconLinkOut';
 import {filterProtocolsWithMissingTranslations, listProtocols} from 'pages/api/protocols';
+import LOCALES from 'utils/locale';
 
 const YEARN_META_GH_PROTOCOL_URI = 'https://github.com/yearn/yearn-meta/blob/master/data/protocols';
 
@@ -30,7 +31,7 @@ function Protocol({name, filename, description, missingTranslationsLocales}) {
 				<p className={'mr-2 dark:text-white break-words text-dark-blue-1'}>
 					<b className={'font-bold'}>{name}</b>
 				</p>
-				<span className={'py-1 px-2 ml-2 text-xs font-bold text-white dark:text-gray-3 bg-yearn-blue rounded-md'}>
+				<span className={'py-1 px-2 ml-2 text-xs font-bold text-white rounded-md dark:text-gray-3 bg-yearn-blue'}>
 					{`Missing ${missingTranslationsLocales.length} translations`}
 				</span>
 				<div className={'flex flex-row justify-center mr-1 ml-auto'}>
@@ -46,7 +47,7 @@ function Protocol({name, filename, description, missingTranslationsLocales}) {
 			</div>
 			<div className={`w-full transition-max-height duration-500 overflow-hidden ${isExpandedAnimation ? 'max-h-max' : 'max-h-0'}`}>
 				{isExpanded ? (
-					<div className={'space-y-2 mt-4'}>
+					<div className={'mt-4 space-y-2'}>
 						<p>{description}</p>
 						<p className={'text-xs'}>{`Missing translations for ${missingTranslationsLocales.map(data => data.name).join(', ')}`}</p>
 					</div>
@@ -58,7 +59,7 @@ function Protocol({name, filename, description, missingTranslationsLocales}) {
 
 function	Index({protocolsList}) {
 	const	[protocols, set_protocols] = React.useState(protocolsList ?? []);
-	const [filterLocale, set_filterLocale] = React.useState('');
+	const [localeFilter, set_localeFilter] = React.useState('');
 	const	[isFetchingData, set_isFetchingData] = React.useState(false);
 	const	{currentNetwork} = useNetwork();
 
@@ -71,8 +72,8 @@ function	Index({protocolsList}) {
 	}
 
 	const protocolsWithMissingTranslations = React.useMemo(() => {
-		return filterProtocolsWithMissingTranslations(protocols, filterLocale);
-	}, [protocols, filterLocale]);
+		return filterProtocolsWithMissingTranslations(protocols, localeFilter);
+	}, [protocols, localeFilter]);
 
 	React.useEffect(() => {
 		refetchData(currentNetwork === 'Ethereum' ? 1 : currentNetwork === 'Fantom' ? 250 : 1);
@@ -101,12 +102,25 @@ function	Index({protocolsList}) {
 									</div>
 								</div>
 								<div className={'mb-8 text-gray-blue-1 dark:text-gray-3'}>
-									{'List of protocols with no translations or missing translations.'}
+									{`List of protocols with no translations or missing translations. (Found ${protocolsWithMissingTranslations.length})`}
+								</div>
+								<div className={'flex flex-row items-center space-x-4'}>
+									<p className={'font-bold'}>{'Filter by locale'}</p>
+									<select
+										value={localeFilter}
+										onChange={e => set_localeFilter(e.target.value)}
+										className={'flex items-center py-2 px-3 pr-7 m-0 mr-1 w-24 text-xs font-semibold whitespace-nowrap rounded-sm border-none cursor-pointer button-light'}
+									>
+										<option className={'cursor-pointer'} value={''}>{'All'}</option>
+										{Object.entries(LOCALES).map(([locale, localeData], index) => (
+											<option className={'cursor-pointer'} key={index} value={locale}>{localeData.name}</option>
+										))}
+									</select>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div className={'w-full'}>
+					<div className={'mt-4 w-full'}>
 						{protocolsWithMissingTranslations.map(protocol => <Protocol key={protocol.name} {...protocol} />)}
 					</div>
 				</div>

--- a/pages/internal/missing-translations.js
+++ b/pages/internal/missing-translations.js
@@ -9,7 +9,7 @@ import	LOCALES							from	'utils/locale';
 
 const META_GH_PROTOCOL_URI = `${process.env.META_GITHUB_URL}/tree/master/data/protocols`;
 
-function Protocol({name, filename, description, missingTranslationsLocales, localeFilter}) {
+function Protocol({name, filename, description, missingTranslationsLocales, localeFilter, localization}) {
 	const	{currentChainId} = useNetwork();
 	const	[isExpanded, set_isExpanded] = React.useState(false);
 	const	[isExpandedAnimation, set_isExpandedAnimation] = React.useState(false);
@@ -35,9 +35,17 @@ function Protocol({name, filename, description, missingTranslationsLocales, loca
 				<p className={'mr-2 dark:text-white break-words text-dark-blue-1'}>
 					<b className={'font-bold'}>{name}</b>
 				</p>
-				<span className={'py-1 px-2 ml-2 text-xs font-bold text-white rounded-md dark:text-gray-3 bg-yearn-blue'}>
-					{`Missing ${missingTranslationCounts} ${missingTranslationCounts > 1 ? 'translations' : 'translation'}`}
-				</span>
+				{
+					!localization ? (
+						<span className={'py-1 px-2 ml-2 text-xs font-bold text-white rounded-md dark:text-gray-3 bg-yearn-blue'}>
+							{'No localization data is found'}
+						</span>
+					) : (
+						<span className={'py-1 px-2 ml-2 text-xs font-bold text-white rounded-md dark:text-gray-3 bg-yearn-blue'}>
+							{`Missing ${missingTranslationCounts} ${missingTranslationCounts > 1 ? 'translations' : 'translation'}`}
+						</span>
+					)
+				}
 				<div className={'flex flex-row justify-center mr-1 ml-auto'}>
 					<a
 						onClick={e => e.stopPropagation()}

--- a/pages/internal/missing-translations.js
+++ b/pages/internal/missing-translations.js
@@ -1,0 +1,64 @@
+import	React							from	'react';
+import	Navbar							from	'components/Navbar';
+import	Vaults							from	'components/Vaults';
+import	HeadIconCogs					from	'components/icons/HeadIconCogs';
+import	{listVaultsWithStrategies}		from	'pages/api/strategies';
+import	useNetwork						from	'contexts/useNetwork';
+
+
+function	Index({vaults}) {
+	const	[vaultList, set_vaultList] = React.useState(vaults);
+	const	[isFetchingData, set_isFetchingData] = React.useState(false);
+	const	[chainExplorer, set_chainExplorer] = React.useState('https://etherscan.io');
+	const	{currentNetwork} = useNetwork();
+
+	async function	refetchData(_currentNetwork) {
+		set_isFetchingData(true);
+		const _data = await listVaultsWithStrategies({network: _currentNetwork});
+		set_vaultList(JSON.parse(_data));
+		set_isFetchingData(false);
+	}
+
+	React.useEffect(() => {
+		refetchData(currentNetwork === 'Ethereum' ? 1 : currentNetwork === 'Fantom' ? 250 : 1);
+		set_chainExplorer(currentNetwork === 'Ethereum' ? 'https://etherscan.io' : currentNetwork === 'Fantom' ? 'http://ftmscan.com' : 'https://etherscan.io');
+	}, [currentNetwork]);
+
+	return (
+		<section className={'p-4 w-full bg-white dark:bg-black rounded-sm'}>
+			<Navbar />
+			<div>
+				<div className={'w-full max-w-5xl'}>
+					<div className={'flex flex-col'}>
+						<div className={'mb-8'}>
+							<HeadIconCogs className={'text-yearn-blue dark:text-white'} />
+						</div>
+						<div className={'w-full'}>
+							<div className={'flex flex-col'}>
+								<div className={'flex flex-row items-center mb-8 w-full'}>
+									<h1 className={'text-4xl font-bold text-dark-blue-1 dark:text-white whitespace-pre-line md:text-6xl'}>
+										{'Translations'}
+									</h1>
+									<div
+										className={'p-2 -m-2 ml-2'}
+										style={{marginTop: -2}}
+										onClick={() => refetchData(currentNetwork === 'Ethereum' ? 1 : currentNetwork === 'Fantom' ? 250 : 1)}>
+										<svg aria-hidden={'true'} className={`w-4 h-4 text-ygray-300 dark:text-dark-50 opacity-30 hover:opacity-100 transition-opacity cursor-pointer ${isFetchingData ? 'animate animate-spin' : ''}`} role={'img'} xmlns={'http://www.w3.org/2000/svg'} viewBox={'0 0 512 512'}><path fill={'currentColor'} d={'M449.9 39.96l-48.5 48.53C362.5 53.19 311.4 32 256 32C161.5 32 78.59 92.34 49.58 182.2c-5.438 16.81 3.797 34.88 20.61 40.28c16.97 5.5 34.86-3.812 40.3-20.59C130.9 138.5 189.4 96 256 96c37.96 0 73 14.18 100.2 37.8L311.1 178C295.1 194.8 306.8 223.4 330.4 224h146.9C487.7 223.7 496 215.3 496 204.9V59.04C496 34.99 466.9 22.95 449.9 39.96zM441.8 289.6c-16.94-5.438-34.88 3.812-40.3 20.59C381.1 373.5 322.6 416 256 416c-37.96 0-73-14.18-100.2-37.8L200 334C216.9 317.2 205.2 288.6 181.6 288H34.66C24.32 288.3 16 296.7 16 307.1v145.9c0 24.04 29.07 36.08 46.07 19.07l48.5-48.53C149.5 458.8 200.6 480 255.1 480c94.45 0 177.4-60.34 206.4-150.2C467.9 313 458.6 294.1 441.8 289.6z'}></path></svg>
+									</div>
+								</div>
+								<div className={'mb-8 text-gray-blue-1 dark:text-gray-3'}>
+									{'List of protocols with no translations or missing translations.'}
+								</div>
+							</div>
+						</div>
+					</div>
+					<div className={'w-full'}>
+						{(vaultList || [])?.filter(e => e.hasMissingStrategiesDescriptions).map((vault) => <Vaults key={vault.name} vault={vault} chainExplorer={chainExplorer} shouldHideValids />)}
+					</div>
+				</div>
+			</div>
+		</section>
+	);
+}
+
+export default Index;

--- a/pages/internal/missing-translations.js
+++ b/pages/internal/missing-translations.js
@@ -9,10 +9,14 @@ import	LOCALES							from	'utils/locale';
 
 const META_GH_PROTOCOL_URI = `${process.env.META_GITHUB_URL}/tree/master/data/protocols`;
 
-function Protocol({name, filename, description, missingTranslationsLocales}) {
+function Protocol({name, filename, description, missingTranslationsLocales, localeFilter}) {
 	const	{currentChainId} = useNetwork();
 	const	[isExpanded, set_isExpanded] = React.useState(false);
 	const	[isExpandedAnimation, set_isExpandedAnimation] = React.useState(false);
+
+	const missingTranslationCounts = React.useMemo(() => {
+		return localeFilter ? 1 : missingTranslationsLocales.length;
+	}, [missingTranslationsLocales, localeFilter]);
 
 	function	onExpand() {
 		if (isExpanded) {
@@ -32,7 +36,7 @@ function Protocol({name, filename, description, missingTranslationsLocales}) {
 					<b className={'font-bold'}>{name}</b>
 				</p>
 				<span className={'py-1 px-2 ml-2 text-xs font-bold text-white rounded-md dark:text-gray-3 bg-yearn-blue'}>
-					{`Missing ${missingTranslationsLocales.length} translations`}
+					{`Missing ${missingTranslationCounts} ${missingTranslationCounts > 1 ? 'translations' : 'translation'}`}
 				</span>
 				<div className={'flex flex-row justify-center mr-1 ml-auto'}>
 					<a
@@ -47,9 +51,9 @@ function Protocol({name, filename, description, missingTranslationsLocales}) {
 			</div>
 			<div className={`w-full transition-max-height duration-500 overflow-hidden ${isExpandedAnimation ? 'max-h-max' : 'max-h-0'}`}>
 				{isExpanded ? (
-					<div className={'mt-4 space-y-2'}>
+					<div className={'mt-4 space-y-2 dark:text-gray-3'}>
 						<p>{description}</p>
-						<p className={'text-xs'}>{`Missing translations for ${missingTranslationsLocales.map(data => data.name).join(', ')}`}</p>
+						{(!localeFilter || localeFilter === 'en') && <p className={'text-xs'}>{`Missing translations for ${missingTranslationsLocales.map(data => data.name).join(', ')}`}</p>}
 					</div>
 				) : <div />}
 			</div>
@@ -105,7 +109,7 @@ function	Index({protocolsList}) {
 									{`List of protocols with no translations or missing translations. (Found ${protocolsWithMissingTranslations.length})`}
 								</div>
 								<div className={'flex flex-row items-center space-x-4'}>
-									<p className={'font-bold'}>{'Filter by locale'}</p>
+									<p className={'font-bold dark:text-gray-3'}>{'Filter by locale'}</p>
 									<select
 										value={localeFilter}
 										onChange={e => set_localeFilter(e.target.value)}
@@ -121,7 +125,7 @@ function	Index({protocolsList}) {
 						</div>
 					</div>
 					<div className={'mt-4 w-full'}>
-						{protocolsWithMissingTranslations.map(protocol => <Protocol key={protocol.name} {...protocol} />)}
+						{protocolsWithMissingTranslations.map(protocol => <Protocol key={protocol.name} localeFilter={localeFilter} {...protocol} />)}
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
## Description

Fixes #45

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Change details

Detail the changes that occur if necessary.

- Add a `internal/missing-translations` page that allows users to see which protocols have no or missing translations.
- Add an API that queries from the `meta.yearn.network` IPFS gateway.
- Add `currentChainId` to the Network context.

## Resources

Below is a screen recording link of the `internal/missing-translations` page:

https://www.loom.com/share/d103b9d1e5cd40a68fecfdf98d1df56b
