### PR TITLE
fix: useEffect dependency array warnings

### DIFF
--- a/components/Menu.js
+++ b/components/Menu.js
@@ -194,7 +194,7 @@ function	MenuDesktop() {
 				}
 			};
 		}
-	}, [head?.current]);
+	}, [router]);
 
 	return (
 		<nav className={'hidden sticky top-0 z-50 px-0 pt-12 w-full h-screen border-r border-gray-blue-3 dark:border-gray-2 shadow-none md:block'}>


### PR DESCRIPTION
## Description
Two warnings are shown in the terminal when the site is run locally in production mode ( `yarn run build && yarn run start` ). This fix resolves the warnings.

<img width="705" alt="warnings" src="https://user-images.githubusercontent.com/95051992/182376472-6a90f8a7-85a5-4f03-b9dd-05fcafd22e91.png">

In the first case `router` is used to navigate to an internal page within the hook so should be included as a dependency. 

In the second case`head.current` is unnecessary because mutating the current value of react refs will never cause a re-render and so never triggers the useEffect.

After resolving the warnings the original functionality remains unchanged. Meaning that the desired internal page is still reachable when the Yearn logo at the top of the page is right clicked. 

## Type of change

- [X] Other - resolves warnings
