### PR TITLE
FRP: Update to new API yDaemon

### DIFF
--- a/components/StandardFooter.js
+++ b/components/StandardFooter.js
@@ -22,7 +22,7 @@ function	Footer() {
 			<a href={'https://yearn.watch'} target={'_blank'} className={'pr-6 text-gray-blue-1 dark:text-gray-3 link'} rel={'noreferrer'}>
 				{common['footer-watch']}
 			</a>
-			<a href={'https://api.yearn.finance/v1/chains/1/vaults/all'} target={'_blank'} className={'pr-6 text-gray-blue-1 dark:text-gray-3 link'} rel={'noreferrer'}>
+			<a href={'https://api.ycorpo.com/1/vaults/all'} target={'_blank'} className={'pr-6 text-gray-blue-1 dark:text-gray-3 link'} rel={'noreferrer'}>
 				{common['footer-vault-api']}
 			</a>
 			<div className={'px-3 ml-auto text-gray-blue-1 dark:text-gray-3 link'}>

--- a/next.config.js
+++ b/next.config.js
@@ -8,7 +8,8 @@ module.exports = ({
 	plugins: [new Dotenv()],
 	images: {
 		domains: [
-			'rawcdn.githack.com'
+			'rawcdn.githack.com',
+			'raw.githubusercontent.com'
 		],
 	},
 	env: {

--- a/pages/api/strategies.js
+++ b/pages/api/strategies.js
@@ -46,7 +46,7 @@ async function getStrategies({network}) {
 		}
 	}
 
-	let		vaults = (await (await fetch(`https://api.yearn.finance/v1/chains/${network}/vaults/all`)).json());
+	let		vaults = (await (await fetch(`https://api.ycorpo.com/${network}/vaults/all`)).json());
 	vaults = vaults.filter(e => !e.migration || !e.migration?.available);
 	vaults = vaults.filter(e => e.type !== 'v1');
 	const	vaultsWithStrats = [];

--- a/pages/api/tokens.js
+++ b/pages/api/tokens.js
@@ -38,7 +38,7 @@ async function getTokens({network}) {
 	}
 
 
-	let		vaults = (await (await fetch(`https://api.yearn.finance/v1/chains/${network}/vaults/all`)).json());
+	let		vaults = (await (await fetch(`https://api.ycorpo.com/${network}/vaults/all`)).json());
 	vaults = vaults.filter(e => !e.migration || !e.migration?.available);
 	vaults = vaults.filter(e => e.type !== 'v1');
 	const	vaultsWithStrats = [];

--- a/pages/api/vaults.js
+++ b/pages/api/vaults.js
@@ -63,7 +63,7 @@ async function getStrategies({network, isCurve, isRetired, isV1, isAll, isStable
 		}
 	}
 
-	let	vaults = (await (await fetch(`https://api.yearn.finance/v1/chains/${network}/vaults/all`)).json());
+	let	vaults = (await (await fetch(`https://api.ycorpo.com/${network}/vaults/all`)).json());
 	if (isRetired) {
 		vaults = vaults.filter(e => e?.migration?.available === true);
 	} else if (isV1) {

--- a/pages/ethereum/curve-pools.js
+++ b/pages/ethereum/curve-pools.js
@@ -33,7 +33,7 @@ function	Index({vaults}) {
 				</div>
 			</div>
 			<div className={'w-full'}>
-				{vaults.map((vault) => <Vaults key={vault.name} vault={vault} chainExplorer={chainExplorer} />)}
+				{vaults.map((vault) => <Vaults key={vault.address} vault={vault} chainExplorer={chainExplorer} />)}
 			</div>
 			<div className={'w-full'}>
 				<div className={'self-center mt-8 md:self-auto'}>

--- a/pages/ethereum/defi-tokens.js
+++ b/pages/ethereum/defi-tokens.js
@@ -29,7 +29,7 @@ function	Index({vaults}) {
 				</div>
 			</div>
 			<div className={'w-full'}>
-				{vaults.map((vault) => <Vaults key={vault.name} vault={vault} chainExplorer={chainExplorer} />)}
+				{vaults.map((vault) => <Vaults key={vault.address} vault={vault} chainExplorer={chainExplorer} />)}
 			</div>
 			<div className={'w-full'}>
 				<div className={'self-center mt-8 md:self-auto'}>

--- a/pages/ethereum/retired-vaults.js
+++ b/pages/ethereum/retired-vaults.js
@@ -29,7 +29,7 @@ function	Index({vaults}) {
 				</div>
 			</div>
 			<div className={'w-full'}>
-				{vaults.map((vault) => <Vaults key={vault.name} vault={vault} chainExplorer={chainExplorer} isRetired />)}
+				{vaults.map((vault) => <Vaults key={vault.address} vault={vault} chainExplorer={chainExplorer} isRetired />)}
 			</div>
 			<div className={'w-full'}>
 				<div className={'self-center mt-8 md:self-auto'}>

--- a/pages/ethereum/stables.js
+++ b/pages/ethereum/stables.js
@@ -29,7 +29,7 @@ function	Index({vaults}) {
 				</div>
 			</div>
 			<div className={'w-full'}>
-				{vaults.map((vault) => <Vaults key={vault.name} vault={vault} chainExplorer={chainExplorer} />)}
+				{vaults.map((vault) => <Vaults key={vault.address} vault={vault} chainExplorer={chainExplorer} />)}
 			</div>
 			<div className={'w-full'}>
 				<div className={'self-center mt-8 md:self-auto'}>

--- a/pages/ethereum/v1-vaults.js
+++ b/pages/ethereum/v1-vaults.js
@@ -29,7 +29,7 @@ function	Index({vaults}) {
 				</div>
 			</div>
 			<div className={'w-full'}>
-				{vaults.map((vault) => <Vaults key={vault.name} vault={vault} chainExplorer={chainExplorer} isRetired />)}
+				{vaults.map((vault) => <Vaults key={vault.address} vault={vault} chainExplorer={chainExplorer} isRetired />)}
 			</div>
 			<div className={'w-full'}>
 				<div className={'self-center mt-8 md:self-auto'}>

--- a/pages/fantom/curve-pools.js
+++ b/pages/fantom/curve-pools.js
@@ -33,7 +33,7 @@ function	Index({vaults}) {
 				</div>
 			</div>
 			<div className={'w-full'}>
-				{vaults.map((vault) => <Vaults key={vault.name} vault={vault} chainExplorer={chainExplorer} />)}
+				{vaults.map((vault) => <Vaults key={vault.address} vault={vault} chainExplorer={chainExplorer} />)}
 			</div>
 			<div className={'w-full'}>
 				<div className={'self-center mt-8 md:self-auto'}>

--- a/pages/fantom/defi-tokens.js
+++ b/pages/fantom/defi-tokens.js
@@ -29,7 +29,7 @@ function	Index({vaults}) {
 				</div>
 			</div>
 			<div className={'w-full'}>
-				{vaults.map((vault) => <Vaults key={vault.name} vault={vault} chainExplorer={chainExplorer} />)}
+				{vaults.map((vault) => <Vaults key={vault.address} vault={vault} chainExplorer={chainExplorer} />)}
 			</div>
 			<div className={'w-full'}>
 				<div className={'self-center mt-8 md:self-auto'}>

--- a/pages/fantom/retired-vaults.js
+++ b/pages/fantom/retired-vaults.js
@@ -29,7 +29,7 @@ function	Index({vaults}) {
 				</div>
 			</div>
 			<div className={'w-full'}>
-				{vaults.map((vault) => <Vaults key={vault.name} vault={vault} chainExplorer={chainExplorer} isRetired />)}
+				{vaults.map((vault) => <Vaults key={vault.address} vault={vault} chainExplorer={chainExplorer} isRetired />)}
 			</div>
 			<div className={'w-full'}>
 				<div className={'self-center mt-8 md:self-auto'}>

--- a/pages/fantom/stables.js
+++ b/pages/fantom/stables.js
@@ -29,7 +29,7 @@ function	Index({vaults}) {
 				</div>
 			</div>
 			<div className={'w-full'}>
-				{vaults.map((vault) => <Vaults key={vault.name} vault={vault} chainExplorer={chainExplorer} />)}
+				{vaults.map((vault) => <Vaults key={vault.address} vault={vault} chainExplorer={chainExplorer} />)}
 			</div>
 			<div className={'w-full'}>
 				<div className={'self-center mt-8 md:self-auto'}>

--- a/pages/internal/missing-descriptions.js
+++ b/pages/internal/missing-descriptions.js
@@ -72,7 +72,7 @@ function	Index({vaults}) {
 						</div>
 					</div>
 					<div className={'w-full'}>
-						{(vaultList || [])?.filter(e => e.hasMissingStrategiesDescriptions).map((vault) => <Vaults key={vault.name} vault={vault} chainExplorer={chainExplorer} shouldHideValids />)}
+						{(vaultList || [])?.filter(e => e.hasMissingStrategiesDescriptions).map((vault) => <Vaults key={vault.address} vault={vault} chainExplorer={chainExplorer} shouldHideValids />)}
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
## Description

Updated the site to use the new API (yDaemon) by updating the URLs used to fetch data. Also fixed 2 errors caused by the data being returned from the yDaemon. 
* First fix involved adding a new image domain to the `next.config.js` to accommodate the icon images returned from the new API.
*  Second fix updated the value we use as a key when mapping  over vaults. This was required because in some cases vault names (Ethereum stables (Dai)) returned from yDaemon were not unique. After adjusting the key to instead be vault.address (which will always be unique) things work as intended. 

I did note some differences in the vaults shown, depending on which API was used to pull data, and was having some trouble understanding the differences fully so wanted to bring it up to see if this is intended behavior. 
* Currently data from the old API shows 3 Curve Pools on Fandom, when using the new API none of these are shown
* Currently data from the old API shows retired v1 vaults for Ethereum, when using the new API none of these are shown


Fixes #56 

## Type of change

- [X] New feature (non-breaking change which adds functionality)
