### PR TITLE
fix: Use yDaemon to fetch strategies

### DIFF
--- a/pages/api/vaults.tsx
+++ b/pages/api/vaults.tsx
@@ -1,7 +1,6 @@
 import {NextApiRequest, NextApiResponse} from 'next/types';
-import {TVaultStrategy, TVaultStrategies, TStratTree, 
-	TStrategyMetadata, TVault, TVaultWithStrats} from 'types';
-import {toAddress} from 'utils';
+import {TVaultStrategy, TVaultStrategies, 
+	TVault, TVaultWithStrats} from 'types';
 
 const	STABLE_UNDERLYING: string[][] = [];
 STABLE_UNDERLYING[1] = [ // ethereum
@@ -26,51 +25,23 @@ STABLE_UNDERLYING[42161] = [ // arbitrum
 ];
 
 
-async function getVaultStrategies(vaultStrategies: TVaultStrategy[], stratTree: TStratTree): Promise<TVaultStrategies> {
-	const 	strategies = [];
-	let		hasMissingStrategiesDescriptions = false;
+async function getVaultStrategies(vaultStrategies: TVaultStrategy[]): Promise<TVaultStrategies> {
+	const strategies = [];
+	let	hasMissingStrategiesDescriptions = false;
 	for (const strategy of vaultStrategies) {
-		const	strategyAddress = toAddress(strategy.address);
-		const	strategyName = strategy.name;
-		const	details = stratTree[strategyAddress];
-		if (details) {
-			if (!details?.description) {
+		if (strategy.details.isActive)
+		{
+			if (!strategy.description) {
 				hasMissingStrategiesDescriptions = true;
 			}
-			strategies.push({
-				address: strategyAddress || '',
-				name: details?.name || strategyName || '',
-				description: (details?.description ? details.description : ''),
-				localization: (details?.localization ? details.localization : {})
-			});	
-		} else {
-			strategies.push({
-				address: strategyAddress || '',
-				name: strategyName || '',
-				description: '',
-				localization: {}
-			});	
-			hasMissingStrategiesDescriptions = true;
+			strategies.push(strategy);	
 		}
 	}
 	return ([strategies, hasMissingStrategiesDescriptions]);
 }
 
 async function getStrategies(network: number, isCurve: boolean, isRetired: boolean, isV1: boolean, isAll: boolean, isStable: boolean, isDefi: boolean):  Promise<TVaultWithStrats[]> {
-	const		allStrategiesAddr: TStrategyMetadata[] = await (await fetch(`${process.env.META_API_URL}/${network}/strategies/all`)).json();
-	const	stratTree: TStratTree = {};
-
-	for (const stratDetails of allStrategiesAddr) {
-		for (const address of stratDetails.addresses) {
-			stratTree[toAddress(address)] = {
-				description: stratDetails.description,
-				name: stratDetails.name,
-				localization: stratDetails.localization
-			};
-		}
-	}
-
-	let	vaults: TVault[] = (await (await fetch(`https://api.yearn.finance/v1/chains/${network}/vaults/all`)).json());
+	let	vaults: TVault[] = (await (await fetch(`https://ydaemon.yearn.finance/${network}/vaults/all?strategiesDetails=withDetails`)).json());
 	if (isRetired) {
 		vaults = vaults.filter((e): boolean => e?.migration?.available || false);
 	} else if (isV1) {
@@ -99,8 +70,7 @@ async function getStrategies(network: number, isCurve: boolean, isRetired: boole
 
 	for (const vault of vaults) {
 		const	[strategies] = await getVaultStrategies(
-			vault.strategies,
-			stratTree
+			vault.strategies
 		);
 
 		vaultsWithStrats.push({

--- a/types/custom/vault.ts
+++ b/types/custom/vault.ts
@@ -9,11 +9,14 @@ export type TVaultProps = {
 }
 
 export type TVaultStrategy = {
-  address: string,
+	address: string,
 	name: string,
 	description: string,
-	localization?: TLocalization,
-	noIPFS?: boolean
+	details: TVaultStrategyDetails
+}
+
+export type TVaultStrategyDetails = {
+	isActive: boolean
 }
 
 export type TVaultStrategies = [strategies: TVaultStrategy[], hasMissingStrategiesDescriptions: boolean];


### PR DESCRIPTION
## Description

Use the new yDaemon API to fetch strategies in order to easily have access to the strategies `isActive` property. There is unfortunately a twist: The yDeamon `/vaults/all` don't currently include v1 vaults. I don't know if it's a bug or by design, I will open an issue on the yDaemon  repo. Another option would be to use the old API when the `getStrategies()` `isV1` parameter is set to `true`. Setting the PR as draft for now because of this issue.

Fixes #46

## Type of change

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change details

N/A

## Resources

N/A
